### PR TITLE
Remove version constraints for com.ibm.icu package imports

### DIFF
--- a/org.eclipse.emf.query/META-INF/MANIFEST.MF
+++ b/org.eclipse.emf.query/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Export-Package: org.eclipse.emf.query,
  org.eclipse.emf.query.internal.statements;x-friends:="org.eclipse.emf.query.tests",
  org.eclipse.emf.query.internal.util;x-friends:="org.eclipse.emf.query.tests",
  org.eclipse.emf.query.statements
-Import-Package: com.ibm.icu.text;version="4.0.0"
+Import-Package: com.ibm.icu.text
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.3.0,3.0.0)"
 Eclipse-LazyStart: true


### PR DESCRIPTION
Follow-up for: https://github.com/eclipse-platform/eclipse.platform.releng/issues/69

Essentially the problem is:

`Root cause is that [..] bundles expect versioned com.ibm.icu.text package to exist in the installation, but 4.25 SDK brings only plain maven artifact without proper package metadata.`

See also:

- https://github.com/eclipse/emf-validation/pull/4
- https://git.eclipse.org/r/c/webtools-common/webtools.common/+/194676
- https://git.eclipse.org/r/c/sourceediting/webtools.sourceediting/+/194679
- https://github.com/eclipse/gef-classic/pull/91